### PR TITLE
Updating ng-lottie to handle SSR scenario

### DIFF
--- a/src/lottieAnimationView.component.ts
+++ b/src/lottieAnimationView.component.ts
@@ -13,9 +13,7 @@ const lottie: any = require('lottie-web/build/player/lottie.js');
 
 export class LottieAnimationViewComponent implements OnInit {
     
-    constructor(@Inject(PLATFORM_ID) platformId: string) {
-       isPlatformBrowser(platformId);
-    }
+    constructor(@Inject(PLATFORM_ID) platformId: string) {}
 
     @Input() options: any;
     @Input() width: number;

--- a/src/lottieAnimationView.component.ts
+++ b/src/lottieAnimationView.component.ts
@@ -29,7 +29,7 @@ export class LottieAnimationViewComponent implements OnInit {
 
     ngOnInit() {
         
-        if(isPlatformServer(platformId)){return;}
+        if(isPlatformServer(this.platformId)){return;}
         
         this._options = {
             container: this.lavContainer.nativeElement,

--- a/src/lottieAnimationView.component.ts
+++ b/src/lottieAnimationView.component.ts
@@ -1,4 +1,6 @@
-import { Component, Input, OnInit, Output, EventEmitter, ViewChild, ElementRef } from '@angular/core';
+import { Component, Input, OnInit, Output, EventEmitter, ViewChild, ElementRef, PLATFORM_ID, Inject } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+
 declare let require: any;
 const lottie: any = require('lottie-web/build/player/lottie.js');
 
@@ -10,6 +12,11 @@ const lottie: any = require('lottie-web/build/player/lottie.js');
 })
 
 export class LottieAnimationViewComponent implements OnInit {
+    
+    constructor(@Inject(PLATFORM_ID) platformId: string) {
+       isPlatformBrowser(platformId);
+    }
+
     @Input() options: any;
     @Input() width: number;
     @Input() height: number;
@@ -23,6 +30,9 @@ export class LottieAnimationViewComponent implements OnInit {
     private _options: any;
 
     ngOnInit() {
+        
+        if(isPlatformServer(platformId)){return;}
+        
         this._options = {
             container: this.lavContainer.nativeElement,
             renderer: 'svg',

--- a/src/lottieAnimationView.component.ts
+++ b/src/lottieAnimationView.component.ts
@@ -13,7 +13,7 @@ const lottie: any = require('lottie-web/build/player/lottie.js');
 
 export class LottieAnimationViewComponent implements OnInit {
     
-    constructor(@Inject(PLATFORM_ID) platformId: string) {}
+    constructor(@Inject(PLATFORM_ID) private platformId: string) {}
 
     @Input() options: any;
     @Input() width: number;


### PR DESCRIPTION
As of the change in https://github.com/airbnb/lottie-web/pull/905/files, SSR no longer works as lottie-web is no longer loaded in an SSR world. This handles that scenario by using internal angular functions to prevent crashing the server in the event lottie doesn't exist.

See https://github.com/chenqingspring/ng-lottie/issues/26

Resolves:

* #19 
* #21 
* #22 
* #26 